### PR TITLE
Fix: migrate from `ndarray.tostring` to `tobytes`

### DIFF
--- a/sphfile/sphfile.py
+++ b/sphfile/sphfile.py
@@ -128,7 +128,7 @@ class SPHFile(object):
                 data = self.time_range(start, stop)
             else:
                 data = self.content
-            fh.writeframes(data.tostring())
+            fh.writeframes(data.tobytes())
         return filename
 
     def write_sph(self, filename, start=None, stop=None,extra_headers=None):


### PR DESCRIPTION
The `ndarray.tostring()` method was deprecated in NumPy 1.19.0 and completely removed in NumPy 2.3. Since `tobytes()` has been the recommended replacement since 1.9.0 (with identical functionality), this change ensures compatibility with newer NumPy versions.

The change:
- Maintains the exact same behavior
- Future-proofs the code against NumPy ≥2.3